### PR TITLE
Fix nested figure tags on p tags on blog posts

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 module.exports = {
   siteMetadata: {
-    siteUrl: "https://example.com",
+    siteUrl: "https://auroradigital.co",
     title: "Aurora Digital's Website",
     author: "Aurora Digital's Website",
   },
@@ -30,6 +30,7 @@ module.exports = {
       resolve: "gatsby-mdx",
       options: {
         gatsbyRemarkPlugins: [
+          "gatsby-remark-unwrap-images",
           {
             resolve: `gatsby-remark-images`,
             options: {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gatsby-plugin-sharp": "^2.0.20",
     "gatsby-plugin-sitemap": "^2.0.5",
     "gatsby-remark-images": "^3.0.11",
+    "gatsby-remark-unwrap-images": "^1.0.1",
     "gatsby-source-filesystem": "^2.0.20",
     "gatsby-transformer-sharp": "^2.1.13",
     "intersection-observer": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5991,6 +5991,14 @@ gatsby-remark-images@^3.0.11:
     unist-util-select "^1.5.0"
     unist-util-visit-parents "^2.0.1"
 
+gatsby-remark-unwrap-images@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-unwrap-images/-/gatsby-remark-unwrap-images-1.0.1.tgz#180472da9e016a127e00eb3a26d4c7370e9d7184"
+  integrity sha512-qBj4PDez/TrAOX/gWtRvklUotT7yYikPvN1XYYDR4PECM9ky1gXIGc1/jqYlLCTja70vgWTHxzPptkRpgw+o4g==
+  dependencies:
+    unist-util-remove "^1.0.1"
+    unist-util-visit "^1.4.0"
+
 gatsby-source-filesystem@^2.0.20:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.0.20.tgz#0bb3dcf905c6856d87e7a44d73bd8ff056cd5b95"


### PR DESCRIPTION
The `gatsby-remark-images` plugin was generating `p` tags around images, causing invalid markup to be generated, in this case, `figcaptions` inside `p` tags, which is not valid (it worked anyway because browsers are not supposed to fail when markup is invalid, but still, it's best we fix it).

This PR adds the `gatsby-remark-unwrap-images` plugin which removes these `p` tags, fixing the issue.