### PR TITLE
Fix "end of times, explosions everywhere" bug

### DIFF
--- a/src/components/FadeUpOnScroll/index.js
+++ b/src/components/FadeUpOnScroll/index.js
@@ -3,8 +3,10 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import { useInView } from "react-intersection-observer";
 
-import "./index.css";
 import useDetectJavascript from "root/hooks/useDetectJavascript";
+import Noscript from "root/components/Noscript";
+
+import "./index.css";
 
 const FadeUpOnScroll = ({ children, className }) => {
   const hasJavascript = useDetectJavascript();
@@ -15,15 +17,18 @@ const FadeUpOnScroll = ({ children, className }) => {
     hide: !hasJavascript,
   });
 
-  useEffect(() => {
-    if (inView) setReadyToAnimate(true);
-  }, [inView]);
+  useEffect(
+    () => {
+      if (inView) setReadyToAnimate(true);
+    },
+    [inView],
+  );
 
   return (
     <>
-      <noscript>
+      <Noscript>
         <div styleName="noscript">{children}</div>
-      </noscript>
+      </Noscript>
       <div className={className} ref={ref} styleName={styles}>
         {children}
       </div>

--- a/src/components/Noscript/index.js
+++ b/src/components/Noscript/index.js
@@ -1,0 +1,20 @@
+/* eslint-disable react/no-danger */
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import PropTypes from "prop-types";
+
+function Noscript({ children }) {
+  return (
+    <noscript
+      dangerouslySetInnerHTML={{
+        __html: renderToStaticMarkup(children).replace(/noscript/g, "div"),
+      }}
+    />
+  );
+}
+
+Noscript.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Noscript;


### PR DESCRIPTION
Use the same hack I created on the Subvisual website. Escaping all `noscript` tags with a special component to avoid those strange extra elements.

The bug itself? Basically ghost elements being duplicated everywhere. 