### PR TITLE
Replace lodash with lodash-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gatsby-transformer-json": "^2.2.26",
     "gatsby-transformer-sharp": "^2.3.14",
     "intersection-observer": "^0.7.0",
-    "lodash": "^4.17.15",
+    "lodash-es": "^4.17.15",
     "postcss-color-function": "^4.1.0",
     "postcss-import": "^12.0.1",
     "postcss-modules": "^1.5.0",

--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import capitalize from "lodash/capitalize";
+import { capitalize } from "lodash-es";
 
 import Section from "root/components/Section";
 import Typography from "root/components/Typography";

--- a/yarn.lock
+++ b/yarn.lock
@@ -8637,6 +8637,11 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
+lodash-es@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
 lodash._arrayeach@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz#bab156b2a90d3f1bbd5c653403349e5e5933ef9e"


### PR DESCRIPTION
It's good practice to use `lodash-es` as it is tree-shakeable. Even though the syntax that we used only imported the `capitalize` function, with `lodash-es` it's easier to not make mistakes and import the whole thing.